### PR TITLE
External headers fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.4.2</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
     </parent>
 
     <groupId>org.voyager</groupId>
     <artifactId>voyager-api</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <name>VoyagerAPI</name>
     <description>API Services for Voyager project</description>
     <packaging>jar</packaging>
@@ -26,7 +26,7 @@
         <jdom.version>1.0</jdom.version>
         <vavr.version>0.10.6</vavr.version>
         <apache-commons.version>3.17.0</apache-commons.version>
-        <voyager-models.version>${project.version}</voyager-models.version>
+        <voyager-models.version>0.1.2</voyager-models.version>
     </properties>
 
     <repositories>

--- a/src/main/java/org/voyager/api/service/utils/ServiceUtils.java
+++ b/src/main/java/org/voyager/api/service/utils/ServiceUtils.java
@@ -3,7 +3,9 @@ package org.voyager.api.service.utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
 import java.util.function.Supplier;
 import static org.voyager.api.error.MessageConstants.EXTERNAL_SERVICE_ERROR_GENERIC_MESSAGE;
@@ -12,9 +14,16 @@ import static org.voyager.api.error.MessageConstants.INTERNAL_SERVICE_ERROR_GENE
 public class ServiceUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceUtils.class);
 
-    public static <T> T handleExternalServiceExceptions(Supplier<T> repositoryFunction) {
+    public static <T> ResponseEntity<T> handleExternalServiceExceptions(Supplier<ResponseEntity<T>> supplier) {
         try {
-            return repositoryFunction.get();
+            ResponseEntity<T> externalResponse = supplier.get();
+            HttpHeaders cleanedHeaders = new HttpHeaders();
+            cleanedHeaders.setContentType(externalResponse.getHeaders().getContentType());
+            return new ResponseEntity<>(
+                    externalResponse.getBody(),
+                    cleanedHeaders,
+                    externalResponse.getStatusCode()
+            );
         } catch (Exception exception) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                     EXTERNAL_SERVICE_ERROR_GENERIC_MESSAGE);


### PR DESCRIPTION
calls to api.voyagerapp.com/geonames* failing due to duplicate headers. updated service utils to strip external call headers.